### PR TITLE
A11Y :: Accessibility Fixes part IV

### DIFF
--- a/components/AriaTooltip.tsx
+++ b/components/AriaTooltip.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { Tooltip, useColorModeValue } from '@chakra-ui/react';
+
+interface AriaTooltipProps {
+	label: string;
+}
+
+const AriaTooltip: React.FC<AriaTooltipProps> = ({ label, children }) => {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<Tooltip
+			label={label}
+			aria-label="Definition of word"
+			color={useColorModeValue('black', 'white')}
+			backgroundColor={useColorModeValue('purple.200', 'purple.500')}
+			padding={2}
+			isOpen={isOpen}
+			pointerEvents="all"
+			onMouseLeave={() => setIsOpen(false)}
+			hasArrow
+		>
+			<span
+				tabIndex={0}
+				onMouseEnter={() => setIsOpen(true)}
+				onFocus={() => setIsOpen(true)}
+				onBlur={() => setIsOpen(false)}
+			>
+				{children}
+			</span>
+		</Tooltip>
+	);
+};
+
+export default AriaTooltip;

--- a/components/FactorManager.tsx
+++ b/components/FactorManager.tsx
@@ -49,7 +49,6 @@ function FactorManager({ title, isFactorActive, children }: FactorManagerProps) 
 					isDisabled={!isFactorActive}
 					onChange={handleCheckboxChange}
 					aria-label={`Toggles the ${title} factor`}
-					aria-selected={factorActiveState}
 				/>
 				<Text
 					as="label"

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -51,13 +51,13 @@ export default function Footer() {
 					<Button onClick={onOpen} variant="footerLink">
 						Supporting Information
 					</Button>
-					{/* <Link href="/faq?tab=supporting-information" as={NextLink} variant="footerLink">
-					Supporting information
-
-				</Link> */}
-
 					<Link href="https://biointeractive.org" target={'_blank'} as={NextLink} variant="footerLink">
-						<Image src="/images/hhmi-biointeractive.svg" width={120} height={25} alt="Logo from HHMI BioInteractive" />
+						<Image
+							src="/images/hhmi-biointeractive.svg"
+							width={120}
+							height={25}
+							alt="HHMI BioInteractive home, opens in new tab"
+						/>
 					</Link>
 				</Container>
 			</Box>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -48,7 +48,7 @@ export default function Footer() {
 					justify={{ base: 'center', md: 'space-between' }}
 					align={{ base: 'center', md: 'center' }}
 				>
-					<Button onClick={onOpen} variant="footerLink">
+					<Button onClick={onOpen} variant="footerButton">
 						Supporting Information
 					</Button>
 					<Link href="https://biointeractive.org" target={'_blank'} as={NextLink} variant="footerLink">

--- a/components/LegendContainer.tsx
+++ b/components/LegendContainer.tsx
@@ -149,7 +149,6 @@ function LegendManager({
 						isChecked={isActive}
 						onChange={handleCheckboxChange}
 						aria-label={`Show/Hides the simulation #${simulationNumber} list of settings and stats`}
-						aria-selected={isActive}
 					/>
 					<Text as="label" htmlFor={checkboxId} style={{ marginLeft: 8 }}>{`Simulation #${simulationNumber}`}</Text>
 				</Box>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -17,6 +17,7 @@ import {
 } from '@chakra-ui/react';
 import { CloseIcon, HamburgerIcon, MoonIcon, SunIcon } from '@chakra-ui/icons';
 import NavLink from './NavLink';
+import { a11yFocus } from '../utils/a11y';
 
 export default function Navigation() {
 	const { colorMode, toggleColorMode } = useColorMode();
@@ -39,6 +40,7 @@ export default function Navigation() {
 							/>
 							<Text
 								fontSize={{
+									xs: '2xs',
 									sm: 'sm',
 									base: 'md',
 								}}
@@ -66,7 +68,13 @@ export default function Navigation() {
 						</HStack>
 					</HStack>
 					<Flex alignItems={'center'}>
-						<Stack direction={'row'} spacing={7}>
+						<Stack
+							direction={'row'}
+							spacing={{
+								xs: 4,
+								base: 7,
+							}}
+						>
 							<Button
 								variant="themeSwitcher"
 								title={colorModeLabel}
@@ -88,7 +96,6 @@ export default function Navigation() {
 						</Stack>
 					</Flex>
 				</Flex>
-
 				{isOpen ? (
 					<Box pb={4} display={{ lg: 'none' }}>
 						<Stack as={'nav'} spacing={4} color="navBarText">
@@ -108,6 +115,17 @@ export default function Navigation() {
 					</Box>
 				) : null}
 			</Box>
+			<Link
+				tabIndex={1}
+				href="#main-content"
+				opacity={0}
+				width="fit-content"
+				margin="10px auto 0 auto"
+				fontWeight="bold"
+				_focus={{ ...a11yFocus, opacity: '1' }}
+			>
+				Skip to main content
+			</Link>
 		</>
 	);
 }

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -35,7 +35,7 @@ export default function Navigation() {
 								src="/images/logo.svg"
 								width={60}
 								height={25}
-								alt="Two curved dotted lines, one concave one convex, intersecting each other"
+								alt="Two curved dotted lines, one concave one convex, intersecting each other, Population Genetics Simulator home"
 								style={{ filter: 'brightness(2)' }}
 							/>
 							<Text

--- a/components/highChart.tsx
+++ b/components/highChart.tsx
@@ -31,13 +31,14 @@ function createLinesFromArray(lines, isGeno = false) {
 	});
 }
 
-function createOptions(theme = 'light', lines, title) {
+function createOptions(theme = 'light', lines, title: string) {
 	const isGenoType = title.toLowerCase().includes('genotype');
 
 	return {
 		title: {
-			text: title || 'Population Genetics Simulation',
-			margin: 50,
+			text: `<h2>${title}</h2>` || '<h2>Population Genetics Simulation</h2>',
+			align: 'center',
+			useHTML: true,
 		},
 		subtitle: {
 			text: 'Hover (or navigate with the keyboard) over the line to see the frequency of the A allele in the population.',

--- a/components/simulator-factors/BaseIndividualSimulation.tsx
+++ b/components/simulator-factors/BaseIndividualSimulation.tsx
@@ -44,7 +44,6 @@ export default function BaseIndividualSimulation({ name, isReplicated }) {
 						checked={infinitePopulationState}
 						onChange={onInfinitePopulationChecked}
 						aria-label="Toggles population size to infinite for the current simulation"
-						aria-selected={infinitePopulationState}
 					>
 						Infinite (∞)
 					</Checkbox>

--- a/components/simulator-factors/BaseIndividualSimulation.tsx
+++ b/components/simulator-factors/BaseIndividualSimulation.tsx
@@ -34,7 +34,9 @@ export default function BaseIndividualSimulation({ name, isReplicated }) {
 					message={populationSize.description}
 					status="info"
 				>
-					<Text fontWeight="bold">{populationSize.sliderName}</Text>
+					<Text as="h3" fontWeight="bold">
+						{populationSize.sliderName}
+					</Text>
 				</HelpContentWrapper>
 				<Stack direction={{ base: 'column', md: 'row' }} mt={4} spacing="24px" align={{ base: 'center' }}>
 					<Slider popVariable={populationSize} isActive={true} isInfinite={!infinitePopulationState} />
@@ -56,7 +58,9 @@ export default function BaseIndividualSimulation({ name, isReplicated }) {
 					message={numberOfGenerations.description}
 					status="info"
 				>
-					<Text fontWeight="bold">{numberOfGenerations.sliderName}</Text>
+					<Text as="h3" fontWeight="bold">
+						{numberOfGenerations.sliderName}
+					</Text>
 				</HelpContentWrapper>
 				<Stack direction={{ base: 'column', md: 'row' }} mt={4} spacing="24px" align={{ base: 'center' }}>
 					<Slider popVariable={numberOfGenerations} isActive={true} />
@@ -69,7 +73,9 @@ export default function BaseIndividualSimulation({ name, isReplicated }) {
 					message={startingAlleleFreq.description}
 					status="info"
 				>
-					<Text fontWeight="bold">{startingAlleleFreq.sliderName}</Text>
+					<Text as="h3" fontWeight="bold">
+						{startingAlleleFreq.sliderName}
+					</Text>
 				</HelpContentWrapper>
 				<Stack direction={{ base: 'column', md: 'row' }} mt={4} spacing="24px" align={{ base: 'center' }}>
 					<Slider popVariable={startingAlleleFreq} isActive={true} />
@@ -83,7 +89,9 @@ export default function BaseIndividualSimulation({ name, isReplicated }) {
 						message={bulkSimulator.description}
 						status="info"
 					>
-						<Text fontWeight="bold">{bulkSimulator.sliderName}</Text>
+						<Text as="h3" fontWeight="bold">
+							{bulkSimulator.sliderName}
+						</Text>
 					</HelpContentWrapper>
 					<Stack direction={{ base: 'column', md: 'row' }} mt={4} spacing="24px" align={{ base: 'center' }}>
 						<Slider popVariable={bulkSimulator} isActive={true} />

--- a/components/simulator-factors/HelpContentWrapper.tsx
+++ b/components/simulator-factors/HelpContentWrapper.tsx
@@ -23,6 +23,16 @@ export default function HelpContentWrapper({ children, title, message, status = 
 
 	const ariaLabel = `Show description for term: ${title}`;
 
+	const onContentClose = () => {
+		if (document.activeElement) {
+			let e = Array.from(document.querySelectorAll('button')) as HTMLElement[];
+			let index = e.indexOf(document.activeElement as HTMLElement) - 1;
+			index = index < 0 ? e.length - 1 : index;
+			e[index].focus();
+			onClose();
+		}
+	};
+
 	return (
 		<>
 			<HStack spacing={4}>
@@ -36,6 +46,8 @@ export default function HelpContentWrapper({ children, title, message, status = 
 					justifyContent={'center'}
 					width={'20px'}
 					height={'20px'}
+					minWidth={'20px'}
+					minHeight={'20px'}
 					color={'#ffffff'}
 					backgroundColor={'var(--chakra-colors-gray-500)'}
 					fontSize={'0.8rem'}
@@ -52,7 +64,7 @@ export default function HelpContentWrapper({ children, title, message, status = 
 				<Alert variant="top-accent" status={status} my="10px">
 					<AlertIcon />
 					<Box maxW="90%">
-						<AlertTitle>{title}</AlertTitle>
+						<AlertTitle marginTop={6}>{title}</AlertTitle>
 						<AlertDescription maxW="90%">{message}</AlertDescription>
 					</Box>
 					<CloseButton
@@ -61,7 +73,7 @@ export default function HelpContentWrapper({ children, title, message, status = 
 						position="absolute"
 						right={'10px'}
 						top={1}
-						onClick={onClose}
+						onClick={onContentClose}
 						_focus={a11yFocus}
 					/>
 				</Alert>

--- a/components/simulator-factors/HelpContentWrapper.tsx
+++ b/components/simulator-factors/HelpContentWrapper.tsx
@@ -64,7 +64,9 @@ export default function HelpContentWrapper({ children, title, message, status = 
 				<Alert variant="top-accent" status={status} my="10px">
 					<AlertIcon />
 					<Box maxW="90%">
-						<AlertTitle marginTop={6}>{title}</AlertTitle>
+						<AlertTitle as="h4" marginTop={6}>
+							{title}
+						</AlertTitle>
 						<AlertDescription maxW="90%">{message}</AlertDescription>
 					</Box>
 					<CloseButton

--- a/components/simulators/IndividualGen.tsx
+++ b/components/simulators/IndividualGen.tsx
@@ -29,6 +29,8 @@ import {
 } from '../../redux/reducers/rootSlice';
 import { StoreState, VALID_SECTIONS } from '../../types';
 import Highcharts from 'highcharts';
+import AriaTooltip from '../AriaTooltip';
+import Head from 'next/head';
 
 function Index() {
 	const dispatch = useDispatch();
@@ -244,6 +246,9 @@ function Index() {
 
 	return (
 		<MainWrapper>
+			<Head>
+				<title>Individual Simulations - Population Genetics Simulator</title>
+			</Head>
 			<Box
 				as="main"
 				id="main-content"
@@ -261,27 +266,19 @@ function Index() {
 					</Text>
 					<Text as="p" my={4}>
 						Adjust the settings for the model below. For the default settings, the population is in{' '}
-						<Tooltip
-							label="When the allele and genotype frequencies in a population stay constant."
-							aria-label="A tooltip"
-							color={useColorModeValue('black', 'white')}
-							backgroundColor={useColorModeValue('purple.200', 'purple.500')}
-							padding={2}
-							hasArrow
-						>
+						<AriaTooltip label="When the allele and genotype frequencies in a population stay constant.">
 							<Text
-								as="span"
+								as="p"
 								display="inline-block"
 								color="text"
 								textDecoration="wavy underline"
 								textDecorationColor="purple.300"
 								textUnderlineOffset={2}
 								fontWeight={800}
-								tabIndex={0}
 							>
 								Hardy-Weinberg equilibrium
 							</Text>
-						</Tooltip>{' '}
+						</AriaTooltip>{' '}
 						You can select “Reset Simulator” to restore the default settings.
 					</Text>
 				</Box>

--- a/components/simulators/IndividualGen.tsx
+++ b/components/simulators/IndividualGen.tsx
@@ -246,6 +246,7 @@ function Index() {
 		<MainWrapper>
 			<Box
 				as="main"
+				id="main-content"
 				padding={{ base: '0 15px 15px 15px', sm: '0 30px 30px 30px', md: '0' }}
 				maxWidth={{ md: '90%', lg: '80%', xl: '70%' }}
 				mx={{ sm: 'auto' }}

--- a/components/simulators/ReplicatedGen.tsx
+++ b/components/simulators/ReplicatedGen.tsx
@@ -28,6 +28,7 @@ import MainWrapper from '../MainWrapper';
 import HighChart from '../highChart';
 import Collapsible from '../Collapsible';
 import FactorManager from '../FactorManager';
+import Head from 'next/head';
 
 function Index() {
 	const dispatch = useDispatch();
@@ -262,6 +263,9 @@ function Index() {
 
 	return (
 		<MainWrapper>
+			<Head>
+				<title>Replicated Simulations - Population Genetics Simulator</title>
+			</Head>
 			<Box
 				as="main"
 				id="main-content"

--- a/components/simulators/ReplicatedGen.tsx
+++ b/components/simulators/ReplicatedGen.tsx
@@ -264,12 +264,13 @@ function Index() {
 		<MainWrapper>
 			<Box
 				as="main"
+				id="main-content"
 				padding={{ base: '0 15px 15px 15px', sm: '0 30px 30px 30px', md: '0' }}
 				maxWidth={{ md: '90%', lg: '80%', xl: '70%' }}
 				mx={{ sm: 'auto' }}
 			>
 				<Box as="section" m={'40px 0'}>
-					<Text textStyle="title" align="center">
+					<Text as="h1" textStyle="title" align="center">
 						Replicated Simulations
 					</Text>
 					<Text as="p" my={4}>

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -60,7 +60,8 @@ function FAQPage({
 		<>
 			<MainWrapper>
 				<Box
-					as="section"
+					as="main"
+					id="main-content"
 					p={7}
 					maxWidth={{ base: '550px', md: '786px', lg: '860px', xl: '1080px' }}
 					mx={{ sm: 'auto' }}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -66,9 +66,9 @@ function Index() {
 							as={NextLink}
 							href="/introduction"
 							variant="primary"
-							bgGradient="linear(to-r, purple.400, purple.500)"
+							bgGradient="linear(to-r, purple.500, purple.700)"
 							_hover={{
-								bgGradient: 'linear(to-r, purple.500, purple.600)',
+								bgGradient: 'linear(to-r, purple.600, purple.800)',
 								shadow: 'xl',
 							}}
 							alignSelf={{
@@ -134,6 +134,7 @@ function Index() {
 						<Link
 							as={NextLink}
 							href="/faq"
+							variant="baseLink"
 							textDecoration="underline"
 							color={useColorModeValue('purple.500', 'purple.300')}
 							fontWeight="semibold"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -38,8 +38,16 @@ function Index() {
 						md: 10,
 					}}
 				>
-					<Box display="flex" flexDirection="column" alignItems={{ base: 'center', md: 'start' }} gap="15px">
+					<Box
+						as="main"
+						id="main-content"
+						display="flex"
+						flexDirection="column"
+						alignItems={{ base: 'center', md: 'start' }}
+						gap="15px"
+					>
 						<Text
+							as="h1"
 							color="text"
 							align={{ base: 'center', md: 'start' }}
 							fontWeight={'extrabold'}

--- a/pages/introduction.tsx
+++ b/pages/introduction.tsx
@@ -18,10 +18,15 @@ import {
 	Heading,
 } from '@chakra-ui/react';
 import IntroCard from '../components/IntroCard';
+import AriaTooltip from '../components/AriaTooltip';
+import Head from 'next/head';
 
 function Index() {
 	return (
 		<MainWrapper>
+			<Head>
+				<title>Introduction - Population Genetics Simulator</title>
+			</Head>
 			<Box
 				as="main"
 				id="main-content"
@@ -51,51 +56,35 @@ function Index() {
 					in the same area and potentially reproduce together. Population genetics is the study of genetic variation
 					within and among populations. It often explores the{' '}
 					{
-						<Tooltip
-							label="Variants of a particular gene or DNA region"
-							aria-label="A tooltip"
-							color={useColorModeValue('black', 'white')}
-							backgroundColor={useColorModeValue('purple.200', 'purple.500')}
-							padding={2}
-							hasArrow
-						>
+						<AriaTooltip label="Variants of a particular gene or DNA region">
 							<Text
-								as="span"
+								as="p"
 								display="inline-block"
 								color="text"
 								textDecoration="wavy underline"
 								textDecorationColor="purple.300"
 								textUnderlineOffset={2}
 								fontWeight={800}
-								tabIndex={0}
 							>
 								alleles
 							</Text>
-						</Tooltip>
+						</AriaTooltip>
 					}{' '}
 					and{' '}
 					{
-						<Tooltip
-							label="An individual's set of alleles for a particular region of DNA"
-							aria-label="A tooltip"
-							color={useColorModeValue('black', 'white')}
-							backgroundColor={useColorModeValue('purple.200', 'purple.500')}
-							padding={2}
-							hasArrow
-						>
+						<AriaTooltip label="An individual's set of alleles for a particular region of DNA">
 							<Text
-								as="span"
+								as="p"
 								display="inline-block"
 								color="text"
 								textDecoration="wavy underline"
 								textDecorationColor="purple.300"
 								textUnderlineOffset={2}
 								fontWeight={800}
-								tabIndex={0}
 							>
 								genotypes
 							</Text>
-						</Tooltip>
+						</AriaTooltip>
 					}{' '}
 					within a population. Learning about population genetics is crucial for understanding evolution, which is a
 					change in the frequencies of a population’s alleles over time. Population genetics can help us better
@@ -203,27 +192,19 @@ function Index() {
 					It’s complicated to track all the genetic information in a population over time. So, biologists studying
 					population genetics often use{' '}
 					{
-						<Tooltip
-							label="Mathematical models describe real-world behaviors and processes using equations. They are a way to simplify and simulate reality, in order to explore the key components of a complex system."
-							aria-label="A tooltip"
-							color={useColorModeValue('black', 'white')}
-							backgroundColor={useColorModeValue('purple.200', 'purple.500')}
-							padding={2}
-							hasArrow
-						>
+						<AriaTooltip label="Mathematical models describe real-world behaviors and processes using equations. They are a way to simplify and simulate reality, in order to explore the key components of a complex system.">
 							<Text
-								as="span"
+								as="p"
 								display="inline-block"
 								color="text"
 								textDecoration="wavy underline"
 								textDecorationColor="purple.300"
 								textUnderlineOffset={2}
 								fontWeight={800}
-								tabIndex={0}
 							>
 								mathematical models
 							</Text>
-						</Tooltip>
+						</AriaTooltip>
 					}{' '}
 					. Models provide a powerful framework to explore questions and predictions about evolution.
 				</Text>
@@ -236,27 +217,20 @@ function Index() {
 					Use the model to explore your own questions about how frequencies are affected by different factors. Like all
 					models, this model makes some simplifying{' '}
 					{
-						<Tooltip
-							label="Conditions that a model assumes to be true, in order to make the system easier to understand and work with"
-							aria-label="A tooltip"
-							color={useColorModeValue('black', 'white')}
-							backgroundColor={useColorModeValue('purple.200', 'purple.500')}
-							padding={2}
-							hasArrow
-						>
+						<AriaTooltip label="Conditions that a model assumes to be true, in order to make the system easier to understand and work with.">
 							<Text
-								as="span"
+								as="p"
 								display="inline-block"
 								color="text"
 								textDecoration="wavy underline"
 								textDecorationColor="purple.300"
 								textUnderlineOffset={2}
 								fontWeight={800}
-								tabIndex={0}
+								title="Conditions that a model assumes to be true, in order to make the system easier to understand and work with."
 							>
 								assumptions
 							</Text>
-						</Tooltip>
+						</AriaTooltip>
 					}{' '}
 				</Text>
 

--- a/pages/introduction.tsx
+++ b/pages/introduction.tsx
@@ -22,7 +22,13 @@ import IntroCard from '../components/IntroCard';
 function Index() {
 	return (
 		<MainWrapper>
-			<Box as="section" p={7} maxWidth={{ base: '550px', md: '860px', lg: '1080px', xl: '1440px' }} mx={{ sm: 'auto' }}>
+			<Box
+				as="main"
+				id="main-content"
+				p={7}
+				maxWidth={{ base: '550px', md: '860px', lg: '1080px', xl: '1440px' }}
+				mx={{ sm: 'auto' }}
+			>
 				<Text
 					color="text"
 					fontWeight={'extrabold'}

--- a/theme/components/button.ts
+++ b/theme/components/button.ts
@@ -1,11 +1,9 @@
 import { defineStyle, defineStyleConfig } from '@chakra-ui/react';
+import { a11yFocus } from '../../utils/a11y';
 
 const baseStyle = defineStyle({
 	_focus: {
-		ring: false,
-		outlineColor: 'purple.500',
-		outlineOffset: 4,
-		outlineWidth: 3,
+		...a11yFocus,
 	},
 });
 

--- a/theme/components/button.ts
+++ b/theme/components/button.ts
@@ -45,7 +45,7 @@ const generateLinkStyle = defineStyle({
 	display: 'flex',
 	mx: 'auto',
 	mt: 4,
-	color: 'green.600',
+	color: 'green.700',
 	border: 2,
 	borderStyle: 'solid',
 	borderColor: 'green.500',
@@ -57,7 +57,7 @@ const generateLinkStyle = defineStyle({
 		borderColor: 'green.300',
 	},
 	_hover: {
-		backgroundColor: 'green.100',
+		backgroundColor: 'blackAlpha.100',
 		_dark: {
 			backgroundColor: 'whiteAlpha.300',
 		},
@@ -100,8 +100,16 @@ const showTableStyle = defineStyle({
 	},
 });
 
+const footerButton = defineStyle({
+	...baseStyle,
+	_focus: {
+		...a11yFocus,
+		outlineColor: 'purple.400',
+	},
+});
+
 const buttonTheme = defineStyleConfig({
-	variants: { baseStyle, primary, secondary, themeSwitcher, generateLinkStyle, showTableStyle },
+	variants: { baseStyle, primary, secondary, themeSwitcher, generateLinkStyle, showTableStyle, footerButton },
 });
 
 export default buttonTheme;

--- a/theme/components/checkbox.ts
+++ b/theme/components/checkbox.ts
@@ -5,22 +5,22 @@ const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpe
 
 const redBox = definePartsStyle({
 	control: {
-		color: 'black',
+		color: 'purple.200',
 		border: '1px solid',
-		borderColor: 'gray.400',
+		borderColor: 'gray.600',
 		bg: 'blackAlpha.200',
 		_hover: {
 			bg: 'blackAlpha.400',
 		},
 		_focus: {
-			borderColor: 'purple.500',
-			boxShadow: '0 0 0 3px rgb(159 122 234 / 60%)',
+			borderColor: 'purple.600',
+			boxShadow: '0 0 0 3px rgb(74 49 135 / 60%)',
 		},
 		_checked: {
-			bg: 'purple.300',
+			bg: 'purple.400',
 			borderColor: 'purple.600',
 			_hover: {
-				bg: 'purple.400',
+				bg: 'purple.500',
 				borderColor: 'purple.800',
 			},
 		},

--- a/theme/components/link.ts
+++ b/theme/components/link.ts
@@ -1,6 +1,14 @@
 import { defineStyle, defineStyleConfig } from '@chakra-ui/react';
 import { a11yFocus } from '../../utils/a11y';
 
+const baseLink = defineStyle({
+	_focus: {
+		...a11yFocus,
+		outlineOffset: 1,
+		outlineWidth: 2,
+	},
+});
+
 const brandPrimary = defineStyle({
 	textDecoration: 'underline',
 	color: 'white',
@@ -18,10 +26,8 @@ const footerLink = defineStyle({
 	color: 'white',
 	fontWeight: 'normal',
 	_focus: {
-		ring: false,
-		outlineColor: 'purple.500',
-		outlineOffset: 4,
-		outlineWidth: 3,
+		...a11yFocus,
+		outlineColor: 'purple.400',
 	},
 });
 
@@ -34,11 +40,12 @@ const navigationLink = defineStyle({
 	rounded: 'md',
 	_focus: {
 		...a11yFocus,
+		outlineColor: 'purple.400',
 	},
 });
 
 const linkTheme = defineStyleConfig({
-	variants: { brandPrimary, footerLink, navigationLink },
+	variants: { baseLink, brandPrimary, footerLink, navigationLink },
 });
 
 export default linkTheme;

--- a/theme/components/link.ts
+++ b/theme/components/link.ts
@@ -1,4 +1,5 @@
 import { defineStyle, defineStyleConfig } from '@chakra-ui/react';
+import { a11yFocus } from '../../utils/a11y';
 
 const brandPrimary = defineStyle({
 	textDecoration: 'underline',
@@ -32,10 +33,7 @@ const navigationLink = defineStyle({
 	paddingY: 3,
 	rounded: 'md',
 	_focus: {
-		ring: false,
-		outlineColor: 'purple.500',
-		outlineOffset: 4,
-		outlineWidth: 3,
+		...a11yFocus,
 	},
 });
 

--- a/theme/foundations/semanticTokens.ts
+++ b/theme/foundations/semanticTokens.ts
@@ -21,11 +21,11 @@ const semanticTokens = {
 			_dark: '#333333',
 		},
 		sliderTrack: {
-			default: 'blue.200',
-			_dark: 'blue.100',
+			default: 'cyan.500',
+			_dark: 'blue.300',
 		},
 		sliderFilledTrack: {
-			default: 'blue.500',
+			default: 'blue.600',
 			_dark: 'blue.500',
 		},
 	},

--- a/theme/highchartTheme.ts
+++ b/theme/highchartTheme.ts
@@ -1,5 +1,5 @@
 const lightTheme = {
-	colors: ['#058DC7', '#50B432', '#ED561B', '#DDDF00', '#24CBE5', '#64E572', '#FF9655', '#FFF263', '#6AF9C4'],
+	colors: ['#058DC7', '#2F855A', '#ED561B', '#949900', '#24CBE5', '#64E572', '#FF9655', '#FFF263', '#6AF9C4'],
 	chart: {
 		backgroundColor: '#fff',
 		borderWidth: 1,

--- a/theme/highchartTheme.ts
+++ b/theme/highchartTheme.ts
@@ -1,5 +1,5 @@
 const lightTheme = {
-	colors: ['#058DC7', '#2F855A', '#ED561B', '#949900', '#24CBE5', '#64E572', '#FF9655', '#FFF263', '#6AF9C4'],
+	colors: ['#058DC7', '#2F855A', '#ED561B', '#949900', '#159DB2', '#1BA12B', '#F55E00', '#A39600', '#08A66C'],
 	chart: {
 		backgroundColor: '#fff',
 		borderWidth: 1,

--- a/utils/a11y.ts
+++ b/utils/a11y.ts
@@ -5,11 +5,14 @@ export const a11yFocus: SystemStyleObject = {
 	outlineColor: 'purple.500',
 	outlineOffset: 4,
 	outlineWidth: 3,
+	_dark: {
+		outlineColor: 'purple.400',
+	},
 };
 
 export const a11yThumbFocus: SystemStyleObject = {
 	ring: false,
-	outlineColor: 'purple.400',
+	outlineColor: 'purple.500',
 	outlineOffset: 1,
 	outlineWidth: 3,
 	_dark: {


### PR DESCRIPTION
> [!NOTE]
> 
> Some of the issues described in the sheet are duplicates of the same root, those are condensed into one change noted below



## Changes


- Titles now behave as such, with `h1`.
  - Terms behave as `h3`, and their description as `h4`
- Help content from factors, now redirect focus correctly after closing.
  - It redirect to the button before it, the help button, correct focus behavior when DOM element is removed.
- No more `aria-selected`.
- Correct contrast on sliders
- Add "Skip to content" button
